### PR TITLE
Increase maximum job list to return from searches

### DIFF
--- a/esss_jenkins.py
+++ b/esss_jenkins.py
@@ -125,7 +125,7 @@ class JenkinsBot(BotPlugin):
         self.log.debug('found {} jobs in total, filtering by {!r}'.format(len(all_job_names), args))
 
         job_names = sorted(filter_jobs_by_find_string(all_job_names, args))
-        if len(job_names) > 20:
+        if len(job_names) > 50:
             yield "This resulted in **{}** jobs, which is too much.\n" \
                   "Try to narrow your research.".format(len(job_names))
             return


### PR DESCRIPTION
20 is too limited because depending on the branch
it will generate more than that; 50 is not really a problem
because we have a lot of vertical space on RocketChat anyway