### PR TITLE
Remove "jenkins" prefix from all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ Create a bot for local development:
 errbot --init
 ```
 
-And edit the generated `config.py` with your username instead of `@CHANGE_ME`.
+And edit the generated `config.py`:
 
-Start it up.
+* Change `@CHANGE_ME` to your username.
+* Change `BOT_EXTRA_PLUGIN_DIR` to point to the current directory.
+
+Start it up with:
 
 ```
 errbot -T

--- a/esss_jenkins.py
+++ b/esss_jenkins.py
@@ -76,7 +76,7 @@ class JenkinsBot(BotPlugin):
         return 'User settings:\n```python\n{}```'.format(pformat(settings))
 
     @botcmd(split_args_with=None)
-    def jenkins_history(self, msg, args):
+    def history(self, msg, args):
         """Returns a list with your job history, including running and previous runs."""
         user = args[0] if args else msg.frm.nick
         settings = self.load_user_settings(user)
@@ -97,7 +97,7 @@ class JenkinsBot(BotPlugin):
 
     @arg_botcmd('user', type=str)
     @arg_botcmd('--confirm', action='store_true')
-    def jenkins_clear(self, msg, user, confirm):
+    def clear(self, msg, user, confirm):
         """Clears your job history."""
         if not confirm:
             return 'Need to pass `--confirm` to this command'
@@ -107,7 +107,7 @@ class JenkinsBot(BotPlugin):
         return 'Job history on the trash.'
 
     @botcmd(split_args_with=None)
-    def jenkins_find(self, msg, args):
+    def find(self, msg, args):
         """Finds jobs based on keywords, separated by spaces (`ETK 1456 sci20 win64,linux64`)."""
         if not args:
             yield dedent("""\
@@ -148,7 +148,7 @@ class JenkinsBot(BotPlugin):
         self.save_user_settings(user, settings)
 
     @botcmd(split_args_with=None)
-    def jenkins_build(self, msg, args):
+    def build(self, msg, args):
         """Triggers jobs by an alias or build number from last `!jenkins find` or `!jenkins history` commands"""
         user = msg.frm.nick
         settings = self.load_user_settings(user)
@@ -205,7 +205,7 @@ class JenkinsBot(BotPlugin):
     @arg_botcmd('search_pattern', nargs='*', help='Job search pattern')
     @arg_botcmd('alias', nargs='?', help='Alias name')
     @arg_botcmd('--parameters', dest='parameters', help='Job parameters')
-    def jenkins_buildalias(self, msg, alias, search_pattern, parameters):
+    def buildalias(self, msg, alias, search_pattern, parameters):
         """Adds a build alias based on keywords and parameters e.g: `!jenkins buildalias r30l rocky30 linux64 --parameters=BM='source'`)."""
         user = msg.frm.nick
         settings = self.load_user_settings(user)
@@ -234,7 +234,7 @@ class JenkinsBot(BotPlugin):
 
 
     @botcmd(split_args_with=None)
-    def jenkins_token(self, msg, args):
+    def token(self, msg, args):
         """Set or get your Jenkins token"""
         user = msg.frm.nick
         settings = self.load_user_settings(user)

--- a/test_esss_jenkins.py
+++ b/test_esss_jenkins.py
@@ -30,16 +30,16 @@ def jenkins_plugin(testbot):
 
 
 def test_token(testbot):
-    testbot.push_message('!jenkins token')
+    testbot.push_message('!token')
     response = testbot.pop_message()
     assert 'Jenkins API Token not configured' in response
     assert 'https://my-server.com/jenkins/user/fry/configure' in response
 
-    testbot.push_message('!jenkins token secret-token')
+    testbot.push_message('!token secret-token')
     response = testbot.pop_message()
     assert response == 'Token saved.'
 
-    testbot.push_message('!jenkins token')
+    testbot.push_message('!token')
     response = testbot.pop_message()
     assert response == 'You API Token is: secret-token (user: fry)'
 
@@ -47,20 +47,20 @@ def test_token(testbot):
 def test_build_alias(testbot):
     from unittest.mock import patch
     
-    testbot.push_message('!jenkins buildalias')
+    testbot.push_message('!buildalias')
     response = testbot.pop_message()
     assert 'Pass alias name, some search keywords, and an optional set of parameters' in response
 
-    testbot.push_message('!jenkins buildalias rr30l rocky30 linux --parameters=EXT=20')
+    testbot.push_message('!buildalias rr30l rocky30 linux --parameters=EXT=20')
     response = testbot.pop_message()
     assert 'Alias registered: rr30l' in response
 
-    testbot.push_message('!jenkins buildalias')
+    testbot.push_message('!buildalias')
     response = testbot.pop_message()
     assert 'Existing aliases' in response
     assert 'rr30l' in response
 
-    testbot.push_message('!jenkins token secret-token')
+    testbot.push_message('!token secret-token')
     response = testbot.pop_message()
     assert response == 'Token saved.'
     
@@ -68,25 +68,25 @@ def test_build_alias(testbot):
 
     with patch.object(jenkins_bot, '_find_all_job_names_filtered') as job_names:
         job_names.return_value = []
-        testbot.push_message('!jenkins build rr30l')
+        testbot.push_message('!build rr30l')
         response = testbot.pop_message()
         assert job_names.call_count == 1
         assert "No job found with pattern: ['rocky30', 'linux']" == response
         
-        testbot.push_message('!jenkins build rr30l 6666')
+        testbot.push_message('!build rr30l 6666')
         response = testbot.pop_message()
         assert job_names.call_count == 2
         assert "No job found with pattern: ['rocky30', 'linux', '6666']" == response
 
         job_names.return_value = ['job_1', 'job_2']
-        testbot.push_message('!jenkins build rr30l 6666')
+        testbot.push_message('!build rr30l 6666')
         response = testbot.pop_message()
         assert job_names.call_count == 3
         assert "Multiple jobs found with pattern" in response
 
         job_names.return_value = ['job_1']
         with patch.object(jenkins_bot, '_post_jenkins_json_request') as post_request:
-            testbot.push_message('!jenkins build rr30l 6666')
+            testbot.push_message('!build rr30l 6666')
             response = testbot.pop_message()
 
             assert job_names.call_count == 4


### PR DESCRIPTION
Let err-bot figure out if the prefix is required based on other
plugins implementing commands with the same name