### PR TITLE
Use a prefix for the token command because it conflicts with Stash

### DIFF
--- a/esss_jenkins.py
+++ b/esss_jenkins.py
@@ -234,7 +234,7 @@ class JenkinsBot(BotPlugin):
 
 
     @botcmd(split_args_with=None)
-    def token(self, msg, args):
+    def jenkins_token(self, msg, args):
         """Set or get your Jenkins token"""
         user = msg.frm.nick
         settings = self.load_user_settings(user)

--- a/test_esss_jenkins.py
+++ b/test_esss_jenkins.py
@@ -30,16 +30,16 @@ def jenkins_plugin(testbot):
 
 
 def test_token(testbot):
-    testbot.push_message('!token')
+    testbot.push_message('!jenkins token')
     response = testbot.pop_message()
     assert 'Jenkins API Token not configured' in response
     assert 'https://my-server.com/jenkins/user/fry/configure' in response
 
-    testbot.push_message('!token secret-token')
+    testbot.push_message('!jenkins token secret-token')
     response = testbot.pop_message()
     assert response == 'Token saved.'
 
-    testbot.push_message('!token')
+    testbot.push_message('!jenkins token')
     response = testbot.pop_message()
     assert response == 'You API Token is: secret-token (user: fry)'
 
@@ -60,7 +60,7 @@ def test_build_alias(testbot):
     assert 'Existing aliases' in response
     assert 'rr30l' in response
 
-    testbot.push_message('!token secret-token')
+    testbot.push_message('!jenkins token secret-token')
     response = testbot.pop_message()
     assert response == 'Token saved.'
     


### PR DESCRIPTION
For some reason err-bot is reloading only the last "token" command.

Add the prefix manually for now.