### PR TITLE
Fix for a bug when searching for 'develop'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
+dist: xenial
 python:
-  - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   - pip install -r dev-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 # unfortunately latest errbot 6.0 is breaking our tests (#16)
 errbot~=5.2
+markdown<3
 pytest
 pytest-mock

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
-errbot
+errbot~=5.2
 pytest
 pytest-mock
+pluggy==0.11

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
+# unfortunately latest errbot 6.0 is breaking our tests (#16)
 errbot~=5.2
 pytest
 pytest-mock
-pluggy==0.11

--- a/esss_jenkins.py
+++ b/esss_jenkins.py
@@ -403,7 +403,7 @@ class JenkinsBot(BotPlugin):
                     raise
             raise
         else:
-            result = response['result']
+            result = response.get('result')
             if result is None:
                 # response like this: {"_class":"hudson.model.FreeStyleBuild","result":null}
                 # means that there's a last build and it is currently running

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 filterwarnings=
     error
-    ignore:::markdown
+    ignore:::markdown.*
     ignore:invalid escape sequence::bottle
     ignore:Using or importing the ABCs::bottle|jinja2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 filterwarnings=
     error
+    ignore:Using the add method to register a processor or pattern
     ignore:::markdown.*
     ignore:invalid escape sequence::bottle
     ignore:Using or importing the ABCs::bottle|jinja2

--- a/test_esss_jenkins.py
+++ b/test_esss_jenkins.py
@@ -229,6 +229,17 @@ def test_bhist(jenkins_plugin, testbot, mocker, LineMatcher):
     assert settings['last_job_listing'] == ['job-A', 'job-B']
 
 
+def test_fetch_job_status(jenkins_plugin, mocker):
+    mocker.patch.object(jenkins_plugin,
+                        '_get_jenkins_json_request',
+                        return_value={"_class": "hudson.model.FreeStyleBuild", "result": None})
+    jenkins_plugin._fetch_job_status("dummy")
+    mocker.patch.object(jenkins_plugin,
+                        '_get_jenkins_json_request',
+                        return_value={"_class": "hudson.model.FreeStyleBuild"})
+    jenkins_plugin._fetch_job_status("dummy")
+
+
 JOBS = [
     'alfasim-fb-ASIM-501-network-refactorings-part1-app-win64',
     'alfasim-fb-ASIM-501-network-refactorings-part1-app-win64g',


### PR DESCRIPTION
Fix for a bug found when trying to search for a branch named 'develop', 
Apparently one of the results was missing a key in the dictionary, so instead of access the key, i'm using `dict.get(<key>)` to return None instead of raise KeyError.